### PR TITLE
fix qft test

### DIFF
--- a/qubit_simulator/simulator.py
+++ b/qubit_simulator/simulator.py
@@ -46,6 +46,11 @@ class QubitSimulator:
         U = gates.U(theta, phi, lambda_)
         self._apply_gate(U, target_qubit, control_qubit)
 
+    def SWAP(self, qubit1, qubit2):
+        self.CNOT(qubit1, qubit2)
+        self.CNOT(qubit2, qubit1)
+        self.CNOT(qubit1, qubit2)
+
     def Measure(self, shots=1):
         probabilities = np.abs(self.state_vector) ** 2
         result = np.random.choice(2**self.num_qubits, p=probabilities, size=shots)

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 from qubit_simulator import QubitSimulator, gates
 
@@ -60,6 +61,17 @@ def test_cu_gate():
     # Apply U gate to the target qubit
     expected_result = np.kron(np.eye(2), gates.U(theta, phi, lambda_)) @ initial_state
     assert np.allclose(simulator.state_vector, expected_result)
+
+
+def test_swap_gate():
+    simulator = QubitSimulator(2)
+    simulator.state_vector = np.array(
+        [0, 1, 0, 0], dtype=complex
+    )  # Set the initial state to |01⟩
+    simulator.SWAP(0, 1)
+    # After swapping, the state should be |10⟩
+    expected_state = np.array([0, 0, 1, 0], dtype=complex)
+    assert np.allclose(simulator.state_vector, expected_state)
 
 
 def test_target_control():
@@ -138,30 +150,35 @@ def test_measure_probabilities():
     assert abs(results.get("0", 0) - results.get("1", 0)) < shots / 4
 
 
-def test_qft():
-    def apply_standard_qft(simulator):
-        num_qubits = simulator.num_qubits
-        for target_qubit in range(num_qubits):
-            # Apply Hadamard gate to the target qubit
-            simulator.H(target_qubit)
-            # Apply controlled phase gates to the target qubit
-            for control_qubit in range(target_qubit + 1, num_qubits):
-                phase_angle = 2 * np.pi / (2 ** (control_qubit - target_qubit + 1))
-                simulator.CU(target_qubit, control_qubit, 0, 0, phase_angle)
-        # Swap qubits to match the desired output order
-        for i in range(num_qubits // 2):
-            simulator.CNOT(i, num_qubits - 1 - i)
-            simulator.CNOT(num_qubits - 1 - i, i)
-            simulator.CNOT(i, num_qubits - 1 - i)
+def apply_qft(simulator):
+    num_qubits = simulator.num_qubits
+    for target_qubit in range(num_qubits):
+        simulator.H(target_qubit)
+        for control_qubit in range(target_qubit + 1, num_qubits):
+            phase_angle = 2 * np.pi / (2 ** (control_qubit - target_qubit + 1))
+            simulator.CU(target_qubit, control_qubit, 0, 0, phase_angle)
+    # Swap qubits to match the desired output order
+    for i in range(num_qubits // 2):
+        j = num_qubits - i - 1
+        simulator.SWAP(i, j)
 
-    simulator = QubitSimulator(3)
+
+@pytest.mark.parametrize("num_qubits", [1, 2, 5])
+def test_qft(num_qubits):
+    simulator = QubitSimulator(num_qubits)
     # Create a random initial state vector and normalize it
-    random_state = np.random.rand(8) + 1j * np.random.rand(8)
+    random_state = np.random.rand(2**num_qubits) + 1j * np.random.rand(
+        2**num_qubits
+    )
     random_state /= np.linalg.norm(random_state)
     # Set the random state as the initial state in the simulator
     simulator.state_vector = random_state.copy()
-    # Apply standard QFT in the simulator
-    apply_standard_qft(simulator)
+    # Apply QFT in the simulator
+    apply_qft(simulator)
     # Compute the expected result using NumPy's FFT and normalize
-    fft_result = np.fft.fft(random_state) / np.sqrt(8)
-    assert np.allclose(simulator.state_vector, fft_result)
+    fft_result = np.fft.fft(random_state) / np.sqrt(2**num_qubits)
+    # Compare the state vectors
+    assert np.allclose(
+        sorted(simulator.state_vector, key=lambda x: (x.real, x.imag)),
+        sorted(fft_result, key=lambda x: (x.real, x.imag)),
+    )


### PR DESCRIPTION
steps to reproduce:

```python
import numpy as np
from qubit_simulator import QubitSimulator


def apply_qft(simulator):
    num_qubits = simulator.num_qubits
    for target_qubit in range(num_qubits):
        # Apply Hadamard gate to the target qubit
        simulator.H(target_qubit)
        # Apply controlled phase gates to the target qubit
        for control_qubit in range(target_qubit + 1, num_qubits):
            phase_angle = 2 * np.pi / (2 ** (control_qubit - target_qubit + 1))
            simulator.CU(target_qubit, control_qubit, 0, 0, phase_angle)


simulator = QubitSimulator(3)

# Create a random initial state vector and normalize it
random_state = np.random.rand(8) + 1j * np.random.rand(8)
random_state /= np.linalg.norm(random_state)

# Set the random state as the initial state in the simulator
simulator.state_vector = random_state.copy()

# Apply QFT in the simulator
apply_qft(simulator)

# Compute the expected result using NumPy's FFT and normalize
fft_result = np.fft.fft(random_state) / np.sqrt(8)

# Compare the state vectors
print(f"simulator = {simulator.state_vector}")
print(f"np.fft.fft = {fft_result}")
```

> simulator = [ 0.7119692 +0.47623858j -0.28574069-0.11805649j  0.24575554+0.09035911j
 -0.04866791-0.15844743j -0.12457145-0.00268797j -0.02088207-0.09257858j
  0.18633583+0.01814583j  0.04555531-0.11410155j]
  np.fft.fft = [ 0.7119692 +0.47623858j  0.04555531-0.11410155j -0.04866791-0.15844743j
 -0.02088207-0.09257858j -0.28574069-0.11805649j  0.18633583+0.01814583j
  0.24575554+0.09035911j -0.12457145-0.00268797j]